### PR TITLE
Fix timestamp format

### DIFF
--- a/room-11.php
+++ b/room-11.php
@@ -29,7 +29,7 @@ class Message implements JsonSerializable
         $content = trim($content);
 
         $tz = new DateTimeZone("UTC");
-        $this->timestamp = DateTimeImmutable::createFromFormat('g:i A', $timestamp, $tz);
+        $this->timestamp = DateTimeImmutable::createFromFormat('H:i', $timestamp, $tz);
         
         $this->content = $content;
     }


### PR DESCRIPTION
Timestamp format seems to have changed, causing the DateTime class to return false instead of a DateTimeImmutable instance.